### PR TITLE
Partially fix Arbror

### DIFF
--- a/data/enemies/arbror_root.lua
+++ b/data/enemies/arbror_root.lua
@@ -57,7 +57,7 @@ function enemy:go()
   end
 end
 
-function enemy:on_hurt(attack, life_points)
+function enemy:on_immobilized()
 
   if not self.immobilized then
     -- Tell Master Arbror that I am immobilized.
@@ -65,11 +65,6 @@ function enemy:on_hurt(attack, life_points)
       self.master_arbror:son_started_immobilized()
     end
   end
-end
-
-function enemy:on_immobilized()
-
-  -- Just immobilized.
   self.immobilized = true
   self:restart()  -- To stop the buit-in behavior of being immobilized.
 end

--- a/data/enemies/master_arbror.lua
+++ b/data/enemies/master_arbror.lua
@@ -127,7 +127,7 @@ end
 
 function enemy:son_started_immobilized()
 
-  if get_nb_sons_immobilized() < nb_sons_immobilized_needed then
+  if enemy:get_nb_sons_immobilized() < nb_sons_immobilized_needed then
     local animation = sprite:get_animation()
 
     if animation == "preparing_son" then


### PR DESCRIPTION
This patch partially fixes the Arbror boss.

One big bug remaining: after hurting Arbror, he will never snap out of his vulnerable state. `stop_vulnerable` is setup to be called from a timer, but the engine cancels all timers when an enemy is hit.
