### PR TITLE
Make launcher script more portable.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ add_custom_target(${quest_name}_data
 # create a script that executes the engine with this quest
 add_custom_command(
   OUTPUT ${quest_name}
-  COMMAND echo '\#!/bin/bash' > ${quest_name}
+  COMMAND echo '\#!/bin/sh' > ${quest_name}
   COMMAND echo 'solarus ${CMAKE_INSTALL_PREFIX}/share/solarus/${quest_name} $*' >> ${quest_name}
 )
 add_custom_target(${quest_name}_command


### PR DESCRIPTION
This is extremely pedantic, but the BSDs do not come with bash installed. This tweak changes the install script from calling #!/bin/bash to #!/bin/sh to make the script more portable (as there is nothing dependent on bash in this simple script).
