### PR TITLE
Fix 'bad $-escape' build error by escaping '$'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ add_custom_target(${quest_name}_data
 add_custom_command(
   OUTPUT ${quest_name}
   COMMAND echo '\#!/bin/sh' > ${quest_name}
-  COMMAND echo 'solarus-run ${SOLARUS_INSTALL_ABSOLUTE_DATADIR}/${quest_name} $*' >> ${quest_name}
+  COMMAND echo 'solarus-run ${SOLARUS_INSTALL_ABSOLUTE_DATADIR}/${quest_name} $$*' >> ${quest_name}
 )
 add_custom_target(${quest_name}_command
   ALL


### PR DESCRIPTION
Perhaps this is something recent ninja versions started to care about, but I'm running into the following error on OpenBSD with ninja 1.7.1:

```
ninja: error: build.ninja:111: bad $-escape (literal $ must be written as $$)
```

If this PR is accepted, the other games will need the same treatment .

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/christopho/zsdx/114)

<!-- Reviewable:end -->
