### PR TITLE
Fix joystick repetition in menu

### DIFF
--- a/data/menus/language.lua
+++ b/data/menus/language.lua
@@ -2,6 +2,7 @@
 -- If a language is already set, we skip this menu.
 
 local language_menu = {}
+local last_joy_axis_move = { 0, 0 }
 
 function language_menu:on_started()
 
@@ -106,19 +107,27 @@ end
 
 function language_menu:on_joypad_axis_moved(axis, state)
 
-  if axis % 2 == 0 then  -- Horizontal axis.
-    if state > 0 then
-      self:direction_pressed(0)
-    elseif state < 0 then
-      self:direction_pressed(4)
-    end
-  else  -- Vertical axis.
-    if state > 0 then
-      self:direction_pressed(6)
-    elseif state < 0 then
-      self:direction_pressed(2)
+  -- Avoid move repetition
+  local handled = last_joy_axis_move[axis % 2] == state
+  last_joy_axis_move[axis % 2] = state
+
+  if not handled then
+    if axis % 2 == 0 then  -- Horizontal axis.
+      if state > 0 then
+        self:direction_pressed(0)
+      elseif state < 0 then
+        self:direction_pressed(4)
+      end
+    else  -- Vertical axis.
+      if state > 0 then
+        self:direction_pressed(6)
+      elseif state < 0 then
+        self:direction_pressed(2)
+      end
     end
   end
+
+  return handled
 end
 
 function language_menu:on_joypad_hat_moved(hat, direction8)

--- a/data/menus/pause.lua
+++ b/data/menus/pause.lua
@@ -4,6 +4,7 @@ return function(game)
   local map_builder = require("menus/pause_map")
   local quest_status_builder = require("menus/pause_quest_status")
   local options_builder = require("menus/pause_options")
+  local last_joy_axis_move = { 0, 0 }
 
   function game:start_pause_menu()
 
@@ -33,6 +34,15 @@ return function(game)
     self.pause_submenus = {}
     self:set_custom_command_effect("action", nil)
     self:set_custom_command_effect("attack", nil)
+  end
+
+  function game:on_joypad_axis_moved(axis, state)
+
+    -- Avoid move repetition
+    local handled = last_joy_axis_move[axis % 2] == state
+    last_joy_axis_move[axis % 2] = state
+
+    return handled
   end
 
 end

--- a/data/menus/savegames.lua
+++ b/data/menus/savegames.lua
@@ -2,6 +2,7 @@
 
 local savegame_menu = {}
 local cloud_width, cloud_height = 111, 88
+local last_joy_axis_move = { 0, 0 }
 
 function savegame_menu:on_started()
 
@@ -104,19 +105,27 @@ end
 
 function savegame_menu:on_joypad_axis_moved(axis, state)
 
-  if axis % 2 == 0 then  -- Horizontal axis.
-    if state > 0 then
-      self:direction_pressed(0)
-    elseif state < 0 then
-      self:direction_pressed(4)
-    end
-  else  -- Vertical axis.
-    if state > 0 then
-      self:direction_pressed(6)
-    elseif state < 0 then
-      self:direction_pressed(2)
+  -- Avoid move repetition
+  local handled = last_joy_axis_move[axis % 2] == state
+  last_joy_axis_move[axis % 2] = state
+
+  if not handled then
+    if axis % 2 == 0 then  -- Horizontal axis.
+      if state > 0 then
+        self:direction_pressed(0)
+      elseif state < 0 then
+        self:direction_pressed(4)
+      end
+    else  -- Vertical axis.
+      if state > 0 then
+        self:direction_pressed(6)
+      elseif state < 0 then
+        self:direction_pressed(2)
+      end
     end
   end
+
+  return handled
 end
 
 function savegame_menu:on_joypad_hat_moved(hat, direction8)


### PR DESCRIPTION
Fix joystick repetition in menu by stopping propagation of "axis moved" event